### PR TITLE
[FEATURE] Adds the badge component

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import * as components from '@/components';
 
 export function install(Vue) {
+  Vue.component('Badge', components.Badge);
   Vue.component('Avatar', components.Avatar);
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,9 @@
 <template>
   <div>
-    <Avatar
-      size="lg"
-      icon="trash"
+    <Badge
+      label="test"
+      text="red-dark"
+      color="red-lightest"
     />
   </div>
 </template>

--- a/src/components/atoms/Badge/Badge.scss
+++ b/src/components/atoms/Badge/Badge.scss
@@ -1,0 +1,13 @@
+@import "@/components/nucleus/index.scss";
+
+.badge {
+  & {
+    overflow: hidden;
+    user-select: none;
+    white-space: nowrap;
+    display: inline-block;
+    text-overflow: ellipsis;
+    padding: spacing(xs) spacing(md);
+    border-radius: border-radius(rounded)
+  }
+}

--- a/src/components/atoms/Badge/Badge.tests.js
+++ b/src/components/atoms/Badge/Badge.tests.js
@@ -1,0 +1,15 @@
+// eslint-disable-next-line
+import { mount } from '@vue/test-utils';
+import Badge from './Badge.vue';
+
+describe('Tests for Badge component', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = mount(Badge);
+  });
+
+  /** @test **/
+  test('is a Vue instance', () => {
+    expect(wrapper.isVueInstance()).toBeTruthy();
+  });
+});

--- a/src/components/atoms/Badge/Badge.vue
+++ b/src/components/atoms/Badge/Badge.vue
@@ -1,0 +1,21 @@
+<template>
+  <div
+    class="badge"
+    :class="{
+      [`bg-${color}`]: !!color,
+      [`text-${text}`]: !!text,
+    }"
+  >
+    <slot>
+      {{ label }}
+    </slot>
+  </div>
+</template>
+
+<style lang="scss">
+  @import "./Badge.scss";
+</style>
+
+<script>
+export { default } from '@/core/atoms/Badge';
+</script>

--- a/src/components/atoms/Badge/README.md
+++ b/src/components/atoms/Badge/README.md
@@ -1,0 +1,29 @@
+# Badge
+
+## API
+
+```jsx
+<Badge
+  label="Label of the badge"
+  text="color-variant-for-text"
+  color="color-variant-for-background"
+>
+  Label of the badge (this overwrites the prop `label`)
+</Badge>
+```
+
+## Props
+
+label
+  - type: `String`
+  - description: Sets the badge\'s label (gets overwritten by the element\'s children)
+
+color
+  - type: `String`
+  - default: `grey-light`
+  - description: Sets the background color of the badge
+
+text
+  - type: `String`
+  - default: `black`
+  - description: Sets the text color of the badge

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,2 @@
 export { default as Avatar } from '@/components/atoms/Avatar/Avatar.vue';
-export { default as Avata2r } from '@/components/atoms/Avatar/Avatar.vue';
+export { default as Badge } from '@/components/atoms/Badge/Badge.vue';

--- a/src/core/atoms/Badge/index.js
+++ b/src/core/atoms/Badge/index.js
@@ -1,0 +1,26 @@
+export default {
+  props: {
+    label: {
+      type: String,
+      description: 'Sets the badge\'s label (gets overwritten by the element\'s children)',
+    },
+    color: {
+      type: String,
+      default: 'grey-light',
+      description: 'Sets the background color of the badge',
+    },
+    text: {
+      type: String,
+      default: 'black',
+      description: 'Sets the text color of the badge',
+    },
+  },
+
+  data() {
+    return {};
+  },
+
+  methods: {},
+
+  computed: {},
+};

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,2 +1,2 @@
 export { default as Avatar } from '@/core/atoms/Avatar';
-export { default as Avatar2 } from '@/core/atoms/Avatar';
+export { default as Badge } from '@/core/atoms/Badge';


### PR DESCRIPTION
# Description

Adds the badge component.

## API

```jsx
<Badge
  label="Label of the badge"
  text="color-variant-for-text"
  color="color-variant-for-background"
>
  Label of the badge (this overwrites the prop `label`)
</Badge>
```

## Props

label
  - type: `String`
  - description: Sets the badge\'s label (gets overwritten by the element\'s children)

color
  - type: `String`
  - default: `grey-light`
  - description: Sets the background color of the badge

text
  - type: `String`
  - default: `black`
  - description: Sets the text color of the badge